### PR TITLE
fix: ci failed on macos-latest

### DIFF
--- a/.github/workflows/install/darwin/bats-core.sh
+++ b/.github/workflows/install/darwin/bats-core.sh
@@ -2,5 +2,5 @@
 set -ex
 
 # Install Bats Core.
-brew unlink bats
+brew unlink bats || :
 brew install bats-core


### PR DESCRIPTION
From the CI error message, it seems that `bats` was not installed on `macos-latest`. 
https://github.com/dfinity/keysmith/runs/4795936094?check_suite_focus=true